### PR TITLE
Improve network scaling to fill viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,7 +264,61 @@
     };
 
     const network = new vis.Network(container, data, options);
-    network.fit({ animation: false });
+
+    function fitNetworkToNodes() {
+      const width = container.clientWidth;
+      const height = container.clientHeight;
+      if (!width || !height || nodeEntries.length === 0) return;
+
+      let minX = Infinity;
+      let maxX = -Infinity;
+      let minY = Infinity;
+      let maxY = -Infinity;
+
+      nodeEntries.forEach(({ x, y }) => {
+        if (Number.isFinite(x) && Number.isFinite(y)) {
+          if (x < minX) minX = x;
+          if (x > maxX) maxX = x;
+          if (y < minY) minY = y;
+          if (y > maxY) maxY = y;
+        }
+      });
+
+      if (!Number.isFinite(minX) || !Number.isFinite(maxX) ||
+          !Number.isFinite(minY) || !Number.isFinite(maxY)) {
+        return;
+      }
+
+      const padding = 50;
+      const rangeX = Math.max(maxX - minX, 1);
+      const rangeY = Math.max(maxY - minY, 1);
+      const scaleX = (width - padding * 2) / rangeX;
+      const scaleY = (height - padding * 2) / rangeY;
+      const scale = Math.max(Math.min(scaleX, scaleY), 0.01);
+      const centerX = (minX + maxX) / 2;
+      const centerY = (minY + maxY) / 2;
+
+      network.moveTo({
+        position: { x: centerX, y: centerY },
+        scale,
+        animation: false
+      });
+    }
+
+    const resizeObserver = typeof ResizeObserver !== "undefined"
+      ? new ResizeObserver(() => fitNetworkToNodes())
+      : null;
+    if (resizeObserver) {
+      resizeObserver.observe(container);
+    } else {
+      window.addEventListener("resize", fitNetworkToNodes);
+    }
+
+    const handleAfterDrawing = () => {
+      fitNetworkToNodes();
+      network.off("afterDrawing", handleAfterDrawing);
+    };
+    network.on("afterDrawing", handleAfterDrawing);
 
     // 👥 Populate user dropdown
     const select = document.getElementById('user-select');

--- a/index.html
+++ b/index.html
@@ -289,7 +289,7 @@
         return;
       }
 
-      const marginRatio = 0.05;
+      const marginRatio = 0.2;
       const rangeX = Math.max(maxX - minX, 1);
       const rangeY = Math.max(maxY - minY, 1);
       const usableWidth = Math.max(width * (1 - marginRatio * 2), 1);

--- a/index.html
+++ b/index.html
@@ -289,7 +289,7 @@
         return;
       }
 
-      const marginRatio = 0.2;
+      const marginRatio = 0.1;
       const rangeX = Math.max(maxX - minX, 1);
       const rangeY = Math.max(maxY - minY, 1);
       const usableWidth = Math.max(width * (1 - marginRatio * 2), 1);

--- a/index.html
+++ b/index.html
@@ -289,11 +289,13 @@
         return;
       }
 
-      const padding = 50;
+      const marginRatio = 0.05;
       const rangeX = Math.max(maxX - minX, 1);
       const rangeY = Math.max(maxY - minY, 1);
-      const scaleX = (width - padding * 2) / rangeX;
-      const scaleY = (height - padding * 2) / rangeY;
+      const usableWidth = Math.max(width * (1 - marginRatio * 2), 1);
+      const usableHeight = Math.max(height * (1 - marginRatio * 2), 1);
+      const scaleX = usableWidth / rangeX;
+      const scaleY = usableHeight / rangeY;
       const scale = Math.max(Math.min(scaleX, scaleY), 0.01);
       const centerX = (minX + maxX) / 2;
       const centerY = (minY + maxY) / 2;


### PR DESCRIPTION
## Summary
- compute the node coordinate bounds to determine the network's center and scale
- automatically refit the vis network viewport on draw and when the pane size changes to minimize empty space

## Testing
- Manual UI verification via browser_container

------
https://chatgpt.com/codex/tasks/task_e_68e48b35b7fc832794f6967d18c32fea