### PR TITLE
Refine portrait mobile split sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,21 +82,30 @@
   @media screen and (orientation: portrait) {
     #split-container {
       flex-direction: column !important;
+      height: 100vh;
+      height: 100dvh;
+    }
+
+    #graph-div,
+    #info-container {
+      flex: 0 0 50vh;
+      flex-basis: min(50vh, 50dvh);
+      max-height: 50vh;
+      max-height: 50dvh;
     }
 
     #graph-div {
-      flex: 0 0 40vh;
       border-right: none;
       border-bottom: 1px solid #ccc;
     }
 
     #info-container {
-      flex: 1;
-      height: 60vh;
+      overflow: hidden;
     }
 
     #info-panel {
       flex: 1;
+      min-height: 0;
       overflow-y: auto;
     }
 


### PR DESCRIPTION
## Summary
- enforce a consistent 50/50 split between the graph and info panes in portrait mode
- use dynamic viewport units so the layout tracks the visible screen height on mobile browsers
- constrain the info container overflow to prevent bleed over its allotted space

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4ee6738c48327b21afe036fe62715